### PR TITLE
cria os models e faz a configuração inicial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ storage/*
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,10 @@ group :development do
   gem "spring"
 end
 
+group :test do
+  gem "simplecov", require: false
+end
+
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # graphql
@@ -27,5 +31,5 @@ gem "graphql", "~> 2.3"
 gem "graphiql-rails"
 
 # Rabbit
-gem 'sneakers'
+gem "sneakers"
 gem "bunny", ">= 2.19.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
     crass (1.0.6)
     date (3.3.4)
     diff-lcs (1.5.1)
+    docile (1.4.0)
     erubi (1.13.0)
     ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
@@ -206,6 +207,12 @@ GEM
       sigdump (~> 0.2.2)
     set (1.1.0)
     sigdump (0.2.5)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sneakers (2.11.0)
       bunny (~> 2.12)
       concurrent-ruby (~> 1.0)
@@ -263,6 +270,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 6.1.7, >= 6.1.7.8)
   rspec-rails (~> 4.1.2)
+  simplecov
   sneakers
   spring
   standard

--- a/app/graphql/mutations/policy_create.rb
+++ b/app/graphql/mutations/policy_create.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Mutations
+  class PolicyCreate < BaseMutation
+    description "Creates a new policy"
+
+    field :policy, Types::PolicyType, null: false
+
+    argument :policy_input, Types::PolicyInputType, required: true
+
+    def resolve(policy_input:)
+      policy = ::Policy.new(**policy_input)
+      raise GraphQL::ExecutionError.new "Error creating policy", extensions: policy.errors.to_hash unless policy.save
+
+      {policy: policy}
+    end
+  end
+end

--- a/app/graphql/types/insured_type.rb
+++ b/app/graphql/types/insured_type.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  class InsuredType < Types::BaseObject
+    field :id, ID, null: false
+    field :name, String, null: false
+    field :cpf, ID, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime
+    field :updated_at, GraphQL::Types::ISO8601DateTime
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,10 +2,6 @@
 
 module Types
   class MutationType < Types::BaseObject
-    # TODO: remove me
-    field :test_field, String, null: false, description: "An example field added by the generator"
-    def test_field
-      "Hello World"
-    end
+    field :policy_create, mutation: Mutations::PolicyCreate
   end
 end

--- a/app/graphql/types/policy_input_type.rb
+++ b/app/graphql/types/policy_input_type.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Types
+  class PolicyInputType < Types::BaseInputObject
+    argument :start_date, GraphQL::Types::ISO8601DateTime, required: true
+    argument :end_date, GraphQL::Types::ISO8601DateTime, required: true
+    argument :insured_id, ID, required: true
+  end
+end

--- a/app/graphql/types/policy_type.rb
+++ b/app/graphql/types/policy_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  class PolicyType < Types::BaseObject
+    field :id, ID, null: false
+    field :start_date, GraphQL::Types::ISO8601DateTime, null: false
+    field :end_date, GraphQL::Types::ISO8601DateTime, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime
+    field :updated_at, GraphQL::Types::ISO8601DateTime
+    field :insured_id, ID, null: false
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -22,9 +22,13 @@ module Types
     # They will be entry points for queries on your schema.
 
     # TODO: remove me
-    field :test_field, String, null: false, description: "An example field added by the generator"
-    def test_field
-      "Hello World!"
+
+    field :policy, Types::PolicyType, null: false, description: "Fetch policy for some id" do
+      argument :id, ID, required: true
+    end
+
+    def policy(id:)
+      Policy.find(id)
     end
   end
 end

--- a/app/models/insured.rb
+++ b/app/models/insured.rb
@@ -1,3 +1,3 @@
 class Insured < ApplicationRecord
-  has_many :policies
+  has_many :policies, dependent: :destroy
 end

--- a/spec/graphql/mutations/policy_create_spec.rb
+++ b/spec/graphql/mutations/policy_create_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe "Policy", type: :request do
+  context "Mutation policy(id)" do
+    let(:query_string) do
+      <<-GRAPHQL
+            mutation($insuredId: ID!, $startDate: ISO8601DateTime!, $endDate: ISO8601DateTime! ) {
+              policyCreate(input: {policyInput: {
+                insuredId: $insuredId
+                startDate: $startDate
+                endDate: $endDate
+                }
+              }
+              ) {
+                policy {
+                  __typename
+                  id
+                  insuredId
+                  startDate
+                  endDate
+                }
+              }
+            }
+      GRAPHQL
+    end
+
+    context "when valid" do
+      it "create a policy" do
+        Insured.create!(name: "Mad Max", cpf: 96151218000)
+
+        result = MyappSchema.execute(query_string, variables: {
+          insuredId: Insured.last.id,
+          startDate: "1985-04-12",
+          endDate: "1985-09-12"
+        })
+
+        policy_result = result["data"]["policyCreate"]["policy"]
+
+        expect(policy_result["__typename"]).to eq("Policy")
+        expect(policy_result["id"]).to eq(Policy.last.id.to_s)
+        expect(policy_result["insuredId"]).to eq(Insured.last.id.to_s)
+        expect(policy_result["startDate"]).to include("1985-04-12")
+        expect(policy_result["endDate"]).to include("1985-09-12")
+      end
+    end
+
+    context "when not valid" do
+      it "raise an error" do
+        Insured.create!(name: "Mad Max", cpf: 96151218000)
+
+        result = MyappSchema.execute(query_string, variables: {
+          insuredId: Insured.last.id,
+          startDate: "1985/04/12",
+          endDate: "1985-09-12"
+        })
+
+        expected_message = "Variable $startDate of type ISO8601DateTime! was provided invalid value"
+
+        expect(result["errors"].first["message"]).to eq(expected_message)
+      end
+    end
+  end
+end

--- a/spec/graphql/types/query_type_spec.rb
+++ b/spec/graphql/types/query_type_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "Policy", type: :request do
+  let(:policy) do
+    Insured.create!(name: "Mad Max", cpf: 96151218000)
+    Policy.create!(start_date: "05/12/1974", end_date: "05/12/2030", insured_id: Insured.find_by(cpf: 96151218000).id)
+  end
+
+  let(:query_string) do
+    <<-GRAPHQL
+          query($id: ID!){
+            policy(id:$id){
+              __typename
+              id
+              insuredId
+            }
+          }
+    GRAPHQL
+  end
+
+  context "Query policy(id)" do
+    context "when valid" do
+      it "load policy by ID" do
+        result = MyappSchema.execute(query_string, variables: {id: policy.id})
+        policy_result = result["data"]["policy"]
+
+        expect(policy_result["id"]).to eq(policy.id.to_s)
+        expect(policy_result["__typename"]).to eq("Policy")
+        expect(policy_result["insuredId"]).to eq(policy.insured_id.to_s)
+      end
+    end
+
+    context "when invalid" do
+      it "raise an error" do
+        expect {
+          MyappSchema.execute(query_string, variables: {id: 3})
+        }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find Policy with 'id'=3")
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
+require 'simplecov'
+SimpleCov.start
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 # Prevent database truncation if the environment is production


### PR DESCRIPTION
## O que mudou
adiciona mutation de criação e query de consulta da policy

## Motivação
O schema GraphQL deve contemplar 1 mutation e 1 query:

## Solução proposta
adicionada a query policy que recebe um ID e retorna uma apólice cadastrada, adicionada a mutation create_policy onde podemos criar uma apólice

## Como testar
Suba o projeto com o comando `docker-compose up`

### GraphiQL:

<details>
<summary><strong>Crie uma nova apólice</strong>  </summary><br>

* certifique-se de ter pelo menos 1 insured criado, caso não possua, rode o comando rails:db:seed
* Acesse http://0.0.0.0:3000/graphiql
* cole o código abaixo

#### Exemplo de Mutation
```GQL
mutation{
  policyCreate(input: {policyInput: {
    insuredId: 1
    startDate: "1994-05-10T00:00:00"
    endDate: "1994-10-11T00:00:00"
  	}
  }
  ) {
    policy {
      __typename
      id
      startDate
      endDate
      insuredId
    }
  }
}
```

### Resposta Esperada

![Captura de tela de 2024-06-25 14-48-44](https://github.com/ventopreto/seguradora/assets/67896322/c6ec02e0-999f-461e-b4be-235d8f3c7466)

</details>

<details>
<summary><strong>Consulte a apólice recém criada</strong>  </summary><br>

* Acesse http://0.0.0.0:3000/graphiql
* cole o código abaixo, substituindo o id, pelo id da apólice criada no exemplo anterior

#### Exemplo de Query
```GQL
query{
  policy(id: 53) {
    id
    startDate
    endDate
    insuredId
  }
}
```

![Captura de tela de 2024-06-25 14-54-27](https://github.com/ventopreto/seguradora/assets/67896322/2b4a197c-316d-45a5-bb8b-2aa0cc1fdcb3)
</details>

## Riscos
Podemos ter algum problema durante a criação ou a consulta de apólices

## Impactos negativos previstos
Nenhum Impacto previsto

## Instruções para deploy
Nenhuma instrução adicional

## Instruções para retorno
rollback padrão desse PR
